### PR TITLE
drivers: fingerprint: Kill FEATURE_SPI_WAKELOCK

### DIFF
--- a/drivers/fingerprint/vfs61xx.h
+++ b/drivers/fingerprint/vfs61xx.h
@@ -66,10 +66,6 @@
 /* Timeout value for polling DRDY signal assertion */
 #define DRDY_TIMEOUT_MS      40
 
-#ifdef ENABLE_SENSORS_FPRINT_SECURE
-#define FEATURE_SPI_WAKELOCK
-#endif
-
 /*
  * Definitions of structures which are used by IOCTL commands
  */


### PR DESCRIPTION
- Phone doesn't sleep at all with this "feature" enabled
- FP behavior is seemingly equivalent to cm-13 with this gone
- Yeah, hacky, but so is the driver implementation

Change-Id: Id2be5c6189b0ee18779e03d9d6a62014653c27a8
